### PR TITLE
Fix TypeError with recent version of Composer

### DIFF
--- a/src/DevScriptProxyCommand.php
+++ b/src/DevScriptProxyCommand.php
@@ -43,6 +43,7 @@ class DevScriptProxyCommand extends BaseCommand
         $command = $this->getApplication()->find('run-script');
 
         $arrayInput = new ArrayInput($args);
-        $command->run($arrayInput, $output);
+        $statusCode = $command->run($arrayInput, $output);
+        return is_numeric($statusCode) ? (int) $statusCode : 0;
     }
 }


### PR DESCRIPTION
This PR fixes the following error that I got with composer 1.10.1:
```
PHP Fatal error:  Uncaught TypeError: Return value of "ScriptsDev\DevScriptProxyCommand::execute()" must be of the type int, "NULL" returned. in /.../vendor/symfony/console/Command/Command.php:258
Stack trace:
#0 /.../vendor/symfony/console/Application.php(912): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 /.../vendor/symfony/console/Application.php(264): Symfony\Component\Console\Application->doRunCommand(Object(ScriptsDev\DevScriptProxyCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /.../vendor/composer/composer/src/Composer/Console/Application.php(281): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Comp in /.../vendor/symfony/console/Command/Command.php on line 258
```
See also:
https://github.com/symfony/console/blob/5fa1caadc8cdaa17bcfb25219f3b53fe294a9935/Command/Command.php#L255-L259
