### PR TITLE
Add support for Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         }
     },
     "require": {
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "~1.0@dev"
+        "composer/composer": "~1.0@dev || ~2.0@dev"
     },
     "extra": {
         "class": "ScriptsDev\\Plugin"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,4 +25,12 @@ class Plugin implements PluginInterface, Capable
 
         $package->setScripts(array_merge_recursive($package->getScripts(), $devScripts));
     }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }


### PR DESCRIPTION
Before this PR we couldn't install *scriptsdev* with Composer 2:
```
$ ./composer.phar --version
Composer version 2.0.0-alpha2 2020-06-24 21:36:18
$ ./composer.phar require neronmoon/scriptsdev --dev
                                                                                                                                          
  [InvalidArgumentException]                                                                                                              
  Package neronmoon/scriptsdev at version  has a PHP requirement incompatible with your PHP version, PHP extensions and Composer version  
                                                                                                                                          
```

Closes #18