### PR TITLE
Fix Call to undefined method Composer\Package\RootAliasPackage::setScripts()

### DIFF
--- a/src/PackageScriptsExtractor.php
+++ b/src/PackageScriptsExtractor.php
@@ -4,7 +4,6 @@ namespace ScriptsDev;
 
 
 use Composer\IO\IOInterface;
-use Composer\Package\AliasPackage;
 use Composer\Package\CompletePackage;
 use Composer\Package\PackageInterface;
 
@@ -28,11 +27,6 @@ class PackageScriptsExtractor
      */
     public function extract(PackageInterface $package)
     {
-        // If we have extra.branch-alias, package will be an instanceof RootAliasPackage instead of RootPackage
-        if ($package instanceof AliasPackage) {
-            $package = $package->getAliasOf();
-        }
-
         if ($package instanceof CompletePackage && isset($_SERVER['argv']) && in_array('--no-dev', $_SERVER['argv'], true)) {
             return array();
         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,7 @@ namespace ScriptsDev;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
+use Composer\Package\AliasPackage;
 use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 
@@ -19,6 +20,10 @@ class Plugin implements PluginInterface, Capable
     public function activate(Composer $composer, IOInterface $io)
     {
         $package = $composer->getPackage();
+        // If we have extra.branch-alias, package will be an instanceof RootAliasPackage instead of RootPackage
+        if ($package instanceof AliasPackage) {
+            $package = $package->getAliasOf();
+        }
 
         $extractor = new PackageScriptsExtractor($io);
         $devScripts = $extractor->extract($package);

--- a/tests/extra-with-branch-alias.json
+++ b/tests/extra-with-branch-alias.json
@@ -26,9 +26,10 @@
   "require": {
     "neronmoon/scriptsdev": "*@dev"
   },
+  "version": "dev-master",
   "extra": {
     "branch-alias": {
-      "dev-master": "*-dev"
+      "dev-master": "99.0.0-dev"
     },
     "scripts-dev": {
       "post-update-cmd": "echo SCRIPTSDEV RULEZ"


### PR DESCRIPTION
I have split this PR in 2 commits on purpose:

the first one shows how to reproduce the undefined method error. By running the testsuite you'll get:
```
  - Installing neronmoon/scriptsdev (dev-fix-setscripts): Symlinking from /home/.../scriptsdev
PHP Fatal error:  Uncaught Error: Call to undefined method Composer\Package\RootAliasPackage::setScripts() in /home/.../scriptsdev/src/Plugin.php:27
Stack trace:
#0 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Plugin/PluginManager.php(236): ScriptsDev\Plugin->activate()
#1 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Plugin/PluginManager.php(205): Composer\Plugin\PluginManager->addPlugin()
#2 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Installer/PluginInstaller.php(62): Composer\Plugin\PluginManager->registerPackage()
#3 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Installer/InstallationManager.php(173): Composer\Installer\PluginInstaller->install()
#4 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Installer/InstallationManager.php(160): Composer\Installer\InstallationManager->install()
#5 /home/.../scriptsdev/vendor/comp in /home/.../scriptsdev/src/Plugin.php on line 27
Traceback (most recent call last):
  File "tests/tests.py", line 64, in <module>
    check('SCRIPTSDEV RULEZ', test('extra-with-branch-alias', ['composer', 'update']))
  File "tests/tests.py", line 34, in check
    raise Exception('EXPECTED\n"%s"\nBUT FOUND\n"%s"' % (expect, actual))
Exception: EXPECTED
"SCRIPTSDEV RULEZ"
BUT FOUND
"string(33) "Composer\Package\RootAliasPackage"

Fatal error: Uncaught Error: Call to undefined method Composer\Package\RootAliasPackage::setScripts() in /home/.../scriptsdev/src/Plugin.php:27
Stack trace:
#0 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Plugin/PluginManager.php(236): ScriptsDev\Plugin->activate()
#1 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Plugin/PluginManager.php(205): Composer\Plugin\PluginManager->addPlugin()
#2 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Installer/PluginInstaller.php(62): Composer\Plugin\PluginManager->registerPackage()
#3 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Installer/InstallationManager.php(173): Composer\Installer\PluginInstaller->install()
#4 /home/.../scriptsdev/vendor/composer/composer/src/Composer/Installer/InstallationManager.php(160): Composer\Installer\InstallationManager->install()
#5 /home/.../scriptsdev/vendor/comp in /home/.../scriptsdev/src/Plugin.php on line 27
"
```